### PR TITLE
Clean up lint issues in role

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -3,6 +3,7 @@
   vars_files:
     - defaults/main.yml
   tasks:
-    - set_fact:
+    - name: Do not teardown virtual machines by default
+      set_fact:
         teardown: false
     - import_tasks: tasks/main.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,16 +2,16 @@
 # tasks file for vm-spinup
 
 - name: Perform spinup
-  block: 
-    - import_tasks: tasks/virthost-basics.yml
+  block:
+    - import_tasks: virthost-basics.yml
       when: "not skip_virthost_depedencies"
 
-    - import_tasks: tasks/spinup.yml
+    - import_tasks: spinup.yml
 
-    - import_tasks: tasks/attach-disks.yml
+    - import_tasks: attach-disks.yml
       when: "spare_disk_attach == true"
   when: not teardown
 
 - name: Perform teardown
-  import_tasks: tasks/teardown.yml
+  import_tasks: teardown.yml
   when: teardown

--- a/tasks/teardown.yml
+++ b/tasks/teardown.yml
@@ -1,24 +1,31 @@
 ---
+- name: Get list of virtual machines
+  virt:
+    command: list_vms
+  register: virt
+
 - name: Destroy all VMs
-  shell: >
+  command: >
     virsh destroy {{ item.name }}
   with_items: "{{ virtual_machines }}"
-  ignore_errors: yes
+  when: item.name in virt.list_vms
 
 - name: Undefine all VMs
-  shell: >
+  command: >
     virsh undefine --remove-all-storage {{ item.name }}
   with_items: "{{ virtual_machines }}"
-  ignore_errors: yes
+  when: item.name in virt.list_vms
 
 - name: Remove spare disk images
   file:
     dest: "{{ spare_disk_location }}/{{ item.name }}.img"
     state: absent
   with_items: "{{ virtual_machines }}"
+  when: item.name in virt.list_vms
 
 - name: Remove spare disk attached semaphor
   file:
     dest: "{{ spare_disk_location }}/.attached-{{ item.name }}"
     state: absent
   with_items: "{{ virtual_machines }}"
+  when: item.name in virt.list_vms


### PR DESCRIPTION
Instead of ignoring a failed command (because the VM isn't actually
available to be remove), pull back a list of VMs using the virt module
and then add a when clause to the commands.

Also changes from shell to command module so allow for a clean pass
of ansible-lint.