### PR TITLE
Add network_type to add external network in virthost

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,16 @@ spare_disk_dev: vdb
 
 ### Network options
 
+`network_type` indicates network environment for the virtual machines. `"default"` has one bridge and others are different for each purpose.
+
 Note that this creates a bridge on the host as the name specified by `bridge_network_name`.
 
 The virtual machines will be bridged to the bridge specified by `bridge_name`.
 
 ```
+# Network type (default/ipv6/kokonet)
+network_type: "default"
+
 # Enables a bridge to the outside LAN
 # (as opposed to using virbr0)
 bridge_name: virbr0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,7 @@ bridge_name: virbr0
 bridge_physical_nic: "enp1s0f1"
 bridge_network_name: "br0"
 bridge_network_cidr: 192.168.1.0/24
+network_type: "default"
 ipv6_enabled: false
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for vm-spinup
 
+- name: Change network type ipv6
+  set_fact:
+    network_type: "ipv6"
+  when: ipv6_enabled == true
+
 - name: Perform spinup
   block:
     - import_tasks: virthost-basics.yml

--- a/tasks/virthost-basics.yml
+++ b/tasks/virthost-basics.yml
@@ -121,7 +121,29 @@
       virt_net:
         name: k8s-ipv6-private
         autostart: yes
-  when: ipv6_enabled
+  when: network_type == "ipv6"
+
+- name: Create data network for kokonet
+  block:
+    - name: Define network namespace
+      virt_net:
+        name: kokonet-data
+        command: define
+        xml: >
+          <network>
+            <name>kokonet-data</name>
+          </network>
+
+    - name: Set network active
+      virt_net:
+        name: kokonet-data
+        state: active
+
+    - name: Set network to autostart
+      virt_net:
+        name: kokonet-data
+        autostart: yes
+  when: network_type == "kokonet"
 
 - name: enable ipv6 forwarding
   sysctl:

--- a/templates/spinup.sh.j2
+++ b/templates/spinup.sh.j2
@@ -40,10 +40,13 @@ DISK=$1.qcow2
 # Bridge for VMs (default on Fedora is {{ bridge_name }})
 BRIDGE={{ bridge_name }}
 
-# IPv6 flag
-ipv6_net=''
-{% if ipv6_enabled %}
-ipv6_net='--network network=k8s-ipv6-private,model=virtio'
+# Additional network
+{% if network_type == "ipv6" %}
+net_ext='--network network=k8s-ipv6-private,model=virtio'
+{% elif network_type == "kokonet" %}
+net_ext='--network network=kokonet-data,model=virtio'
+{% else %}
+net_ext=''
 {% endif %}
 
 # Start clean
@@ -103,11 +106,11 @@ _EOF_
     echo "[INFO] Installing with the following parameters:"
     echo "virt-install --import --name $1 --ram $MEM --vcpus $CPUS --disk \
     $DISK,format=qcow2,bus=virtio --disk $CI_ISO,device=cdrom --network \
-    bridge={{ bridge_name }},model=virtio $ipv6_net --os-type=linux --os-variant=rhel6 --noautoconsole"
+    bridge={{ bridge_name }},model=virtio $net_ext --os-type=linux --os-variant=rhel6 --noautoconsole"
 
     virt-install --import --name $1 --ram $MEM --vcpus $CPUS --disk \
     $DISK,format=qcow2,bus=virtio --disk $CI_ISO,device=cdrom --network \
-    bridge={{ bridge_name }},model=virtio $ipv6_net --os-type=linux --os-variant=rhel6 --noautoconsole
+    bridge={{ bridge_name }},model=virtio $net_ext --os-type=linux --os-variant=rhel6 --noautoconsole
 
     MAC=$(virsh domiflist $1 | grep {{ bridge_name }} | awk '{print $5}')
     while true


### PR DESCRIPTION
This patch adds new variable "network_type" to speicfy external network in virthost. 
Currently "default", "ipv6" and "kokonet" are supported.