### PR TITLE
[hotfix][minor] adds option to skip --cpus parameter for nested virt with qemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ image_destination_name: CentOS-7-x86_64-GenericCloud.qcow2
 skip_virthost_depedencies: false
 ```
 
+#### Less frequently utilized options
+
+One less used option is in the case of nested virtualization and using QEMU, 
+you may need to work-around setting the vCPUs, and can do so by setting, which 
+will cause there to be no `--vcpus` flag set during `virt-install`.
+
+```
+nested_virt_qemu_skip_vcpus: true
+```
+
+
 ## License
 
 Apache v2.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,10 @@ virtual_machines:
   - name: kube-node-3
     node_type: nodes
 
+# With qemu and a nested virt situation one may 
+# need to skip specifying the vcpus
+nested_virt_qemu_skip_vcpus: false
+
 # Disk options -----------------------------------------
 
 # Spare disk sizes (for virtual machines)

--- a/templates/spinup.sh.j2
+++ b/templates/spinup.sh.j2
@@ -30,6 +30,7 @@ MEM=${2:-{{ system_default_ram_mb }}}
 
 # Number of virtual CPUs
 CPUS=${3:-{{ system_default_cpus }}}
+{% if nested_virt_qemu_skip_vcpus %}#{% endif %}PARAM_VCPUS="--vcpus $CPUS"
 
 # Cloud init files
 USER_DATA=user-data
@@ -104,11 +105,11 @@ _EOF_
 
     echo "$(date -R) Installing the domain and adjusting the configuration..."
     echo "[INFO] Installing with the following parameters:"
-    echo "virt-install --import --name $1 --ram $MEM --vcpus $CPUS --disk \
+    echo "virt-install --import --name $1 --ram $MEM $PARAM_VCPUS --disk \
     $DISK,format=qcow2,bus=virtio --disk $CI_ISO,device=cdrom --network \
     bridge={{ bridge_name }},model=virtio $net_ext --os-type=linux --os-variant=rhel6 --noautoconsole"
 
-    virt-install --import --name $1 --ram $MEM --vcpus $CPUS --disk \
+    virt-install --import --name $1 --ram $MEM $PARAM_VCPUS --disk \
     $DISK,format=qcow2,bus=virtio --disk $CI_ISO,device=cdrom --network \
     bridge={{ bridge_name }},model=virtio $net_ext --os-type=linux --os-variant=rhel6 --noautoconsole
 


### PR DESCRIPTION
I discovered that while using nested virtualization if one using QEMU, the hosts may not properly boot if you specify the `--vcpus` option. This adds a variable to skip that step if necessary.

Related to: https://github.com/redhat-nfvpe/kube-ansible/issues/161