### PR TITLE
[enhance] Speed up package installation

### DIFF
--- a/tasks/virthost-basics.yml
+++ b/tasks/virthost-basics.yml
@@ -2,21 +2,8 @@
 
 - name: Install required packages
   package:
-    name: "{{ item }}"
+    name: virt-manager,libvirt,libvirt-daemon-kvm,nano,tcpdump,net-tools,libvirt-client,virt-install,genisoimage,nmap,libvirt-python,python-lxml
     state: present
-  with_items:
-    - virt-manager
-    - libvirt
-    - libvirt-daemon-kvm
-    - nano
-    - tcpdump
-    - net-tools
-    - libvirt-client
-    - virt-install
-    - genisoimage
-    - nmap
-    - libvirt-python
-    - python-lxml
 
 - name: Start and enable libvirtd
   service:


### PR DESCRIPTION
Turns out, the documention for Ansible was wrong, and that optimization
of a with_items list sent to the package (or yum) module does not happen
as documented.

In order to not have installation of packages done one at a time (which
instantiates an instance of yum for every row, making installation slow)
you need to pass the list of items to Ansible as a comma separated list.

In the future, the intention is to be able to provide a list directly
to the name argument, but that isn't implemented yet.