### PR TITLE
Add npwg-poc1 support and improve virthost network management

### DIFF
--- a/tasks/teardown.yml
+++ b/tasks/teardown.yml
@@ -30,6 +30,49 @@
   with_items: "{{ virtual_machines }}"
   when: item.name in virt.list_vms
 
+- name: Get list of VM networks
+  virt_net:
+    command: info
+  register: networks
+
+- name: Delete subnetworks
+  block:
+  - name: Delete network for IPv6
+    block:
+      - name: Destroy network for IPv6
+        virt_net:
+          command: destroy
+          name: k8s_ipv6_private
+      - name: Undefine network for IPv6
+        virt_net:
+          command: undefine
+          name: k8s_ipv6_private
+    when: networks.networks.k8s_ipv6_private is defined
+
+  - name: Delete network for kokonet-lab
+    block:
+      - name: Destroy network for kokonet-lab
+        virt_net:
+          command: destroy
+          name: kokonet_data
+      - name: Undefine network for kokonet-lab
+        virt_net:
+          command: undefine
+          name: kokonet_data
+    when: networks.networks.kokonet_data is defined
+
+  - name: Delete network for npwg-poc1
+    block:
+      - name: Destroy network for npwg-poc1
+        virt_net:
+          command: destroy
+          name: npwg_poc1_net
+      - name: Undefine network for npwg-poc1
+        virt_net:
+          command: undefine
+          name: npwg_poc1_net
+    when: networks.networks.npwg_poc1_net is defined
+
 - name: Remove virtual machine directory
   file:
     dest: "{{ images_directory }}/{{ item.name }}"

--- a/tasks/virthost-basics.yml
+++ b/tasks/virthost-basics.yml
@@ -93,21 +93,21 @@
   block:
     - name: Define network namespace
       virt_net:
-        name: k8s-ipv6-private
+        name: k8s_ipv6_private
         command: define
         xml: >
           <network ipv6='yes'>
-            <name>k8s-ipv6-private</name>
+            <name>k8s_ipv6_private</name>
           </network>
 
     - name: Set network active
       virt_net:
-        name: k8s-ipv6-private
+        name: k8s_ipv6_private
         state: active
 
     - name: Set network to autostart
       virt_net:
-        name: k8s-ipv6-private
+        name: k8s_ipv6_private
         autostart: yes
   when: network_type == "ipv6"
 
@@ -115,23 +115,45 @@
   block:
     - name: Define network namespace
       virt_net:
-        name: kokonet-data
+        name: kokonet_data
         command: define
         xml: >
           <network>
-            <name>kokonet-data</name>
+            <name>kokonet_data</name>
           </network>
 
     - name: Set network active
       virt_net:
-        name: kokonet-data
+        name: kokonet_data
         state: active
 
     - name: Set network to autostart
       virt_net:
-        name: kokonet-data
+        name: kokonet_data
         autostart: yes
   when: network_type == "kokonet"
+
+- name: Create secondary network for npwg poc1
+  block:
+    - name: Define network namespace
+      virt_net:
+        name: npwg_poc1_net
+        command: define
+        xml: >
+          <network>
+            <name>npwg_poc1_net</name>
+          </network>
+
+    - name: Set network active
+      virt_net:
+        name: npwg_poc1_net
+        state: active
+
+    - name: Set network to autostart
+      virt_net:
+        name: npwg_poc1_net
+        autostart: yes
+  when: network_type == "npwg-poc1"
 
 - name: enable ipv6 forwarding
   sysctl:

--- a/templates/spinup.sh.j2
+++ b/templates/spinup.sh.j2
@@ -43,9 +43,11 @@ BRIDGE={{ bridge_name }}
 
 # Additional network
 {% if network_type == "ipv6" %}
-net_ext='--network network=k8s-ipv6-private,model=virtio'
+net_ext='--network network=k8s_ipv6_private,model=virtio'
 {% elif network_type == "kokonet" %}
-net_ext='--network network=kokonet-data,model=virtio'
+net_ext='--network network=kokonet_data,model=virtio'
+{% elif network_type == "npwg-poc1" %}
+net_ext='--network network=npwg_poc1_net,model=virtio'
 {% else %}
 net_ext=''
 {% endif %}


### PR DESCRIPTION
This fix introduces new network_type, npwg-poc1, with additional
NIC for secondary network. In addition, fix the issue about clean
up non-default network (i.e. ipv6, kokonet and npwg-poc1 case).

Currently ansible does not support hyphen '-' for variable name,
hence need to replace '-' into '_' in network name, due to virt_net.