### PR TITLE
Fix spinup.sh.j2 to support non static ip case.

### DIFF
--- a/templates/spinup.sh.j2
+++ b/templates/spinup.sh.j2
@@ -101,6 +101,7 @@ instance-id: $1
 local-hostname: $1
 _EOF_
 
+{% if system_network is defined %}
 if [ $# -eq 4 ]; then
     cat >> $META_DATA << _EOF_
 network-interfaces: |
@@ -115,6 +116,7 @@ network-interfaces: |
     dns-search {{ system_dns_search }}
 _EOF_
 fi
+{% endif %}
 
     echo "$(date -R) Copying template image..."
     cp $IMAGE $DISK


### PR DESCRIPTION
This change is to fix #20, to escape to create network-interface
section in metadata, including 'iface eth0 inet static'.