### PR TITLE
[feature] Adds ability to enable huge pages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@
 teardown: false
 
 # Virtual Machines ------------------------------------
-
+hugepages_enabled: false
 default_ansible_user: centos    # default user to login as via ansible
 ssh_proxy_enabled: false
 ssh_proxy_user: root

--- a/templates/spinup.sh.j2
+++ b/templates/spinup.sh.j2
@@ -32,6 +32,15 @@ MEM=${2:-{{ system_default_ram_mb }}}
 CPUS=${3:-{{ system_default_cpus }}}
 {% if nested_virt_qemu_skip_vcpus %}#{% endif %}PARAM_VCPUS="--vcpus $CPUS"
 
+# Enable huge pages?
+{% if not hugepages_enabled %}#{% endif %}PARAM_HUGEPAGES="--memorybacking hugepages=yes"
+{% if hugepages_enabled %}
+if [ "$MEM" -lt "4096" ]; then
+    echo "ERROR: Recommend you use 4096mb or more RAM when enabling hugepages"
+    exit 1
+fi
+{% endif %}
+
 # Cloud init files
 USER_DATA=user-data
 META_DATA=meta-data
@@ -127,11 +136,11 @@ fi
 
     echo "$(date -R) Installing the domain and adjusting the configuration..."
     echo "[INFO] Installing with the following parameters:"
-    echo "virt-install --import --name $1 --ram $MEM $PARAM_VCPUS --disk \
+    echo "virt-install --import --name $1 --ram $MEM $PARAM_VCPUS $PARAM_HUGEPAGES --disk \
     $DISK,format=qcow2,bus=virtio --disk $CI_ISO,device=cdrom --network \
     bridge={{ bridge_name }},model=virtio $net_ext --os-type=linux --os-variant=rhel6 --noautoconsole"
 
-    virt-install --import --name $1 --ram $MEM $PARAM_VCPUS --disk \
+    virt-install --import --name $1 --ram $MEM $PARAM_VCPUS $PARAM_HUGEPAGES --disk \
     $DISK,format=qcow2,bus=virtio --disk $CI_ISO,device=cdrom --network \
     bridge={{ bridge_name }},model=virtio $net_ext --os-type=linux --os-variant=rhel6 --noautoconsole
 


### PR DESCRIPTION
Should be a fairly isolated change, I think. Basically just through virt-install options.

FWIW, I got a tip from Billy to use XML that looks like:

```
 <domain ...>
    <memory unit='KiB'>4194304</memory> 
    <currentMemory unit='KiB'>4194304</currentMemory>
    <memoryBacking>
      <hugepages/>
    </memoryBacking>
</domain>
```

And to Add QEMU namespace and hugepage backing information:

```
  <domain type='kvm'>
  <domain type='kvm' id='10' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
    <qemu:commandline>
      <qemu:arg value='-object'/>
      <qemu:arg value='memory-backend-file,id=mem,size=4096M,mem-path=/mnt/huge,share=on'/>
      <qemu:arg value='-numa'/>
      <qemu:arg value='node,memdev=mem'/>
      <qemu:arg value='-mem-prealloc'/>
    </qemu:commandline>
  </domain>
```

This essentially ignores the qemu arguments.