### PR TITLE
Make attached disk persistent

### DIFF
--- a/tasks/attach-disks.yml
+++ b/tasks/attach-disks.yml
@@ -12,7 +12,7 @@
 
 - name: Attach disk
   shell: >
-    virsh attach-disk "{{ item.name }}" {{ spare_disk_location }}/{{ item.name }}.img {{ spare_disk_dev }} --cache none &&
+    virsh attach-disk --persistent "{{ item.name }}" {{ spare_disk_location }}/{{ item.name }}.img {{ spare_disk_dev }} --cache none &&
     touch {{ spare_disk_location }}/.attached-{{ item.name }}
   args:
     creates: "{{ spare_disk_location }}/.attached-{{ item.name }}"


### PR DESCRIPTION
When rebooting a domain with the attached disk, the disk is not
persistent, and thus not reattached on reboot. Adds a flag to the
disk attachment phase that should allow the disk to be reattached
when the domain reboots.

Closes #29