### PR TITLE
Add OCP4 BYOR style install support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,17 @@
       when: "spare_disk_attach == true"
   when: not teardown
 
+# OCP4 configuration
+- block:
+    - name: Perform OCP4 configs
+      import_tasks: ocp4-setup.yml
+      when: not teardown
+
+    - name: Perform OCP4 cleanups
+      import_tasks: ocp4-cleanup.yml
+      when: teardown
+  when: ocp4_install | default('False') | bool
+
 - name: Perform teardown
   import_tasks: teardown.yml
   when: teardown

--- a/tasks/ocp4-cleanup.yml
+++ b/tasks/ocp4-cleanup.yml
@@ -1,0 +1,49 @@
+---
+# DNS configuration
+- name: Get IP Addresses for all VMs
+  command: >
+    cat /tmp/{{ item.name }}.ip.txt
+  register: vm_ip_addresses
+  changed_when: false
+  with_items: "{{ virtual_machines }}"
+  tags:
+    - skip_ansible_lint
+    # Skip ANSIBLE0012 because we want the IP addresses every time
+
+- name: Populate dictionary of IPs
+  set_fact:
+    vm_ips_dict: "{{ vm_ips_dict|default({}) | combine( {item.item.name: item.stdout} ) }}"
+  with_items: "{{ vm_ip_addresses.results }}"
+
+- name: Remove DNS entry
+  block:
+    - name: Remove master
+      #debug: msg="{{ item.name }}, {{ vm_ips_dict[item.name] }}"
+      shell: >
+        virsh net-update default delete dns-host "<host ip='{{ vm_ips_dict[item.name] }}'></host>"
+      ignore_errors: True
+      with_items: "{{ virtual_machines }}"
+    - name: Remove etcd-client-ssl.tcp entry
+      shell: |
+        virsh net-update default delete dns-srv \
+            "<srv service='etcd-client-ssl' protocol='tcp' \
+              domain='{{ ocp4_cluster_name }}.{{ ocp4_base_domain }}' \
+              target='{{ ocp4_cluster_name }}-etcd-0.{{ ocp4_base_domain }}' \
+              port='2379' priority='10' weight='10'/>" \
+            --live --config
+      ignore_errors: True
+    - name: Remove etcd-server-ssl.tcp entry
+      shell: |
+        virsh net-update default delete dns-srv \
+            "<srv service='etcd-server-ssl' protocol='tcp' \
+              domain='{{ ocp4_cluster_name }}.{{ ocp4_base_domain }}' \
+              target='{{ ocp4_cluster_name }}-etcd-0.{{ ocp4_base_domain }}' \
+              port='2380' priority='10' weight='10'/>" \
+            --live --config
+      ignore_errors: True
+  when: teardown | default('False') | bool
+
+- name: Delete the switch DNS script
+  file: path=/root/ocp4-change-dns.sh
+    state=absent
+  when: (teardown | default('False') | bool)

--- a/tasks/ocp4-setup.yml
+++ b/tasks/ocp4-setup.yml
@@ -1,0 +1,47 @@
+---
+- name: Add DNS entry
+  block:
+    - name: Add bootstrap DNS entry
+      shell: |
+        virsh net-update default add dns-host "<host ip='{{ vm_ips_dict[item.name] }}'> \
+            <hostname>{{ ocp4_cluster_name }}.{{ ocp4_base_domain }}</hostname> \
+            <hostname>{{ ocp4_cluster_name }}-api.{{ ocp4_base_domain }}</hostname> \
+            <hostname>{{ item.name }}.{{ ocp4_base_domain }}</hostname></host>"
+      when: item.node_type == "bootstrap"
+      with_items: "{{ virtual_machines }}"
+    - name: Add master DNS entry
+      shell: |
+        virsh net-update default add dns-host "<host ip='{{ vm_ips_dict[item.name] }}'> \
+            <hostname>{{ ocp4_cluster_name }}-etcd-0.{{ ocp4_base_domain }}</hostname> \
+            <hostname>{{ ocp4_cluster_name }}-master-0.{{ ocp4_base_domain }}</hostname> \
+            <hostname>{{ item.name }}.{{ ocp4_base_domain }}</hostname></host>"
+      when: item.node_type == "masters"
+      with_items: "{{ virtual_machines }}"
+    - name: Add workers DNS entry
+      shell: |
+        virsh net-update default add dns-host "<host ip='{{ vm_ips_dict[item.name] }}'> \
+            <hostname>{{ item.name }}.{{ ocp4_base_domain }}</hostname></host>"
+      when: item.node_type == "workers"
+      with_items: "{{ virtual_machines }}"
+    - name: Add etcd-client-ssl.tcp entry
+      shell: |
+        virsh net-update default add dns-srv \
+            "<srv service='etcd-client-ssl' protocol='tcp' \
+              domain='{{ ocp4_cluster_name }}.{{ ocp4_base_domain }}' \
+              target='{{ ocp4_cluster_name }}-etcd-0.{{ ocp4_base_domain }}' \
+              port='2379' priority='10' weight='10'/>" \
+            --live --config
+    - name: Add etcd-server-ssl.tcp entry
+      shell: >
+        virsh net-update default add dns-srv \
+            "<srv service='etcd-server-ssl' protocol='tcp' \
+              domain='{{ ocp4_cluster_name }}.{{ ocp4_base_domain }}' \
+              target='{{ ocp4_cluster_name }}-etcd-0.{{ ocp4_base_domain }}' \
+              port='2380' priority='10' weight='10'/>" \
+            --live --config
+
+- name: Template the switch DNS script
+  template:
+    src: ocp4-change-dns.sh.j2
+    dest: /root/ocp4-change-dns.sh
+    mode: 0755

--- a/templates/ocp4-change-dns.sh.j2
+++ b/templates/ocp4-change-dns.sh.j2
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Removing old host entries
+{% for vm in virtual_machines %}
+{% if vm.node_type in ["masters", "bootstrap"] %}
+virsh net-update default delete dns-host "<host ip='{{ vm_ips_dict[vm.name] }}'></host>"
+{% endif %}
+{% endfor %}
+
+{% for vm in virtual_machines %}
+{% if vm.node_type == "bootstrap" %}
+# Adding bootstrap without api entry
+virsh net-update default add dns-host \
+  "<host ip='{{ vm_ips_dict[vm.name] }}'> \
+    <hostname>{{ ocp4_cluster_name }}.{{ ocp4_base_domain }}</hostname> \
+    <hostname>{{ vm.name }}.{{ ocp4_base_domain }}</hostname> \
+  </host>"
+{% endif %}
+
+{% if vm.node_type == "masters" %}
+# Adding master with api entry
+virsh net-update default add dns-host \
+  "<host ip='{{ vm_ips_dict[vm.name] }}'> \
+    <hostname>{{ ocp4_cluster_name }}-api.{{ ocp4_base_domain }}</hostname> \
+    <hostname>{{ ocp4_cluster_name }}-etcd-0.{{ ocp4_base_domain }}</hostname> \
+    <hostname>{{ ocp4_cluster_name }}-master-0.{{ ocp4_base_domain }}</hostname> \
+    <hostname>{{ vm.name }}.{{ ocp4_base_domain }}</hostname> \
+   </host>"
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Add flag 'ocp4_install' to add OCP4 specific operation, i.e. DNS.
Currently only 1 master node support (multiple master is TBD).