### PR TITLE
Dev/simplify net

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,7 +53,7 @@ ipv6_enabled: false
 # Virtualization Host options --------------------------
 
 images_directory: /home/images
-centos_genericcloud_url: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1905.qcow2"
+centos_genericcloud_url: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1907.qcow2"
 image_archive_name: CentOS-7-x86_64-GenericCloud.qcow2.xz
 image_destination_name: CentOS-7-x86_64-GenericCloud.qcow2
 

--- a/tasks/virthost-basics.yml
+++ b/tasks/virthost-basics.yml
@@ -144,7 +144,7 @@
       virt_net:
         name: multus_2nics
         autostart: yes
-  when: network_type == "multus-2nics" or network_type == "none-2nics"
+  when: network_type == "2nics"
 
 - name: enable ipv6 forwarding
   sysctl:

--- a/templates/spinup.sh.j2
+++ b/templates/spinup.sh.j2
@@ -74,7 +74,7 @@ BRIDGE={{ bridge_name }}
 # Additional network
 {% if network_type == "ipv6" %}
 net_ext='--network network=k8s_ipv6_private,model=virtio'
-{% elif network_type == "multus-2nics" or network_type == "none-2nics" %}
+{% elif network_type == "2nics" %}
 net_ext='--network network=multus_2nics,model=virtio'
 {% else %}
 net_ext=''


### PR DESCRIPTION
This PR changes `none-2nics` to `2nics` to simplify kube-ansible by unsupporting to install CNI plugins: flannel/weave/multus because user can easily install it after provision (e.g. kubectl create -f http://....)